### PR TITLE
Closes #9 - Context Stack

### DIFF
--- a/iac/context_stack/context_stack.py
+++ b/iac/context_stack/context_stack.py
@@ -1,0 +1,32 @@
+import aws_cdk
+from aws_cdk import (
+    aws_dynamodb as dynamodb,
+)
+from constructs import Construct
+
+
+class ContextStack(aws_cdk.Stack):
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        env: aws_cdk.Environment,
+        application_ci: str,
+        **kwargs,
+    ) -> None:
+
+        super().__init__(scope, construct_id, env=env, **kwargs)
+
+        table = dynamodb.TableV2(
+            self,
+            "context_table",
+            table_name=f"{application_ci}-context",
+            billing=dynamodb.Billing.on_demand(),
+            removal_policy=aws_cdk.RemovalPolicy.DESTROY,
+            partition_key=dynamodb.Attribute(
+                name="PK", type=dynamodb.AttributeType.STRING
+            ),
+            sort_key=dynamodb.Attribute(name="SK", type=dynamodb.AttributeType.NUMBER),
+            # stream=dynamodb.StreamViewType.NEW_AND_OLD_IMAGES,  # is this obsolete?
+        )

--- a/iac/regional_stack.py
+++ b/iac/regional_stack.py
@@ -6,6 +6,7 @@ import aws_cdk
 from database_stack.database_stack import DatabaseStack
 from data_stack.data_stack import DataStack
 from knowledge_base_stack.knowledge_base_stack import KnowledgeBaseStack
+from context_stack.context_stack import ContextStack
 
 
 class RegionalStack(aws_cdk.Stack):
@@ -43,4 +44,12 @@ class RegionalStack(aws_cdk.Stack):
             database_name=database_stack.database_name,
             bucket_arn=data_stack.data_bucket.bucket_arn,
             bucket_name=data_stack.data_bucket.bucket_name,
+        )
+
+        # Stack 4 - Context stack. May move this to app side.
+        context_stack = ContextStack(
+            self,
+            "context_stack",
+            env=env,
+            application_ci=application_ci,
         )


### PR DESCRIPTION
Closes #9 - Context Stack

This stack adds a simple DynamoDB table to the stack that can me used as a (prompt, response) key-value store for storing LLM session context. The upcoming inference stack will read / write to it while interacting with the LLM.

This can be used in addition to / in lieu of a app side context cache. 